### PR TITLE
ToJSON instance for Currency

### DIFF
--- a/Ripple/Amount.hs
+++ b/Ripple/Amount.hs
@@ -26,6 +26,13 @@ instance Show Currency where
 	show XRP = "XRP"
 	show (Currency (a,b,c) adr) = [a,b,c,'/'] ++ show adr
 
+instance Aeson.ToJSON Currency where
+	toJSON XRP = Aeson.object [T.pack "currency" .= "XRP"]
+	toJSON (Currency (a,b,c) issuer) = Aeson.object [
+			T.pack "currency" .= [a,b,c],
+			T.pack "issuer" .= show issuer
+		]
+
 instance Binary Currency where
 	get = do
 		CurrencySpecifier code <- get


### PR DESCRIPTION
Requesting book_offers requires specifying two currencies.  Actually, it looks like the ToJSON instance of Amount (with arbitrary `value`) would work, but only with IOUs; for XRP you seem to need what this does.
